### PR TITLE
Framework for StatusFile 

### DIFF
--- a/lib/triglav/agent.rb
+++ b/lib/triglav/agent.rb
@@ -9,6 +9,7 @@ require 'triglav/agent/error'
 require 'triglav/agent/hash_util'
 require 'triglav/agent/logger'
 require 'triglav/agent/storage_file'
+require 'triglav/agent/status'
 require 'triglav/agent/timer'
 require 'triglav/agent/version'
 

--- a/lib/triglav/agent/base/worker.rb
+++ b/lib/triglav/agent/base/worker.rb
@@ -13,13 +13,14 @@ module Triglav::Agent
       # serverengine interface
       def initialize
         @timer = Timer.new
+        reload_status
       end
 
       # serverengine interface
       def reload
         $logger.info { "Worker#reload worker_id:#{worker_id}" }
         $setting.reload
-        Triglav::Agent::Status.select_resource_uri_prefixes!(resource_uri_prefixes)
+        reload_status
       end
 
       # serverengine interface
@@ -72,6 +73,10 @@ module Triglav::Agent
       end
 
       private
+
+      def reload_status
+        Triglav::Agent::Status.select_resource_uri_prefixes!(resource_uri_prefixes)
+      end
 
       def processor_class
         Configuration.processor_class

--- a/lib/triglav/agent/base/worker.rb
+++ b/lib/triglav/agent/base/worker.rb
@@ -1,4 +1,5 @@
 require 'triglav/agent/timer'
+require 'triglav/agent/status'
 
 module Triglav::Agent
   module Base
@@ -18,6 +19,7 @@ module Triglav::Agent
       def reload
         $logger.info { "Worker#reload worker_id:#{worker_id}" }
         $setting.reload
+        Triglav::Agent::Status.select_resource_uri_prefixes!(resource_uri_prefixes)
       end
 
       # serverengine interface

--- a/lib/triglav/agent/status.rb
+++ b/lib/triglav/agent/status.rb
@@ -1,0 +1,68 @@
+require_relative 'storage_file'
+require 'set'
+
+module Triglav::Agent
+  class Status
+    attr_accessor :path
+    attr_reader :resource_uri_prefix, :resource_uri
+
+    VERSION = :v1
+
+    def initialize(resource_uri_prefix, resource_uri)
+      @path = $setting.status_file
+      @resource_uri_prefix = resource_uri_prefix.to_sym
+      @resource_uri = resource_uri.to_sym
+      @parents = [VERSION, @resource_uri_prefix, @resource_uri]
+    end
+
+    # set(val)
+    # set(key, val)
+    # set(key1, key2, val)
+    # set([key], val)
+    # set([key1, key2], val)
+    def set(*args)
+      val = args.pop
+      keys = args.flatten
+      StorageFile.set(path, [*@parents, *keys], val)
+    end
+
+    # setnx(val)
+    # setnx(key, val)
+    # setnx(key1, key2, val)
+    # setnx([key], val)
+    # setnx([key1, key2], val)
+    def setnx(*args)
+      val = args.pop
+      keys = args.flatten
+      StorageFile.setnx(path, [*@parents, *keys], val)
+    end
+
+    # getsetnx(val)
+    # getsetnx(key, val)
+    # getsetnx(key1, key2, val)
+    # getsetnx([key], val)
+    # getsetnx([key1, key2], val)
+    def getsetnx(*args)
+      val = args.pop
+      keys = args.flatten
+      StorageFile.getsetnx(path, [*@parents, *keys], val)
+    end
+
+    # get(key)
+    # get(key1, key2)
+    # get([key])
+    # get([key1, key2])
+    def get(*args)
+      keys = (args || []).flatten
+      StorageFile.get(path, [*@parents, *keys])
+    end
+
+    def self.select_resource_uri_prefixes!(resource_uri_prefixes)
+      Triglav::Agent::StorageFile.select!($setting.status_file, [VERSION], resource_uri_prefixes.map(&:to_sym))
+    end
+
+    def self.select_resource_uris!(resource_uri_prefix, resource_uris)
+      Triglav::Agent::StorageFile.select!($setting.status_file, [VERSION, resource_uri_prefix.to_sym], resource_uris.map(&:to_sym))
+    end
+  end
+end

--- a/lib/triglav/agent/storage_file.rb
+++ b/lib/triglav/agent/storage_file.rb
@@ -153,7 +153,7 @@ module Triglav::Agent
         if dig = (parents.empty? ? params : params.dig(*parents))
           removes = dig.keys - keys
           unless removes.empty?
-            $logger.info { "remove from status where #{{parent_keys: parents, leaf_keys: removes}}" }
+            $logger.info { "Remove from status: #{{parent_keys: parents, keys: removes}}" }
             removes.each {|k| dig.delete(k) }
           end
         end

--- a/lib/triglav/agent/storage_file.rb
+++ b/lib/triglav/agent/storage_file.rb
@@ -152,7 +152,10 @@ module Triglav::Agent
         params = fp.load
         if dig = (parents.empty? ? params : params.dig(*parents))
           removes = dig.keys - keys
-          removes.each {|k| dig.delete(k) }
+          unless removes.empty?
+            $logger.info { "remove from status where #{{parent_keys: parents, leaf_keys: removes}}" }
+            removes.each {|k| dig.delete(k) }
+          end
         end
         fp.dump(params)
       end

--- a/lib/triglav/agent/storage_file.rb
+++ b/lib/triglav/agent/storage_file.rb
@@ -1,5 +1,6 @@
 require 'triglav/agent/hash_util'
 require 'yaml'
+require 'set'
 
 module Triglav::Agent
   # Thread and inter-process safe YAML file storage
@@ -139,6 +140,22 @@ module Triglav::Agent
     # @param [Hash] hash
     def dump(hash)
       File.write(@fp.path, YAML.dump(hash))
+    end
+
+    # Keep specified keys, and remove others
+    #
+    # @param [String] path
+    # @param [Array] parent keys of hash
+    # @param [Array] keys
+    def self.select!(path, parents = [], keys)
+      open(path) do |fp|
+        params = fp.load
+        if dig = (parents.empty? ? params : params.dig(*parents))
+          removes = dig.keys - keys
+          removes.each {|k| dig.delete(k) }
+        end
+        fp.dump(params)
+      end
     end
   end
 end

--- a/test/test_storage_file.rb
+++ b/test/test_storage_file.rb
@@ -31,4 +31,13 @@ class TestStorageFile < Test::Unit::TestCase
     assert { Triglav::Agent::StorageFile.getsetnx(file, ['a','b'], 'new') == 'bar' }
     assert { Triglav::Agent::StorageFile.getsetnx(file, ['a','new'], 'new') == 'new' }
   end
+
+  def test_select!
+    Triglav::Agent::StorageFile.set(file, ['a','a'], 'val')
+    Triglav::Agent::StorageFile.set(file, ['a','b'], 'val')
+    Triglav::Agent::StorageFile.set(file, ['a','c'], 'val')
+    Triglav::Agent::StorageFile.select!(file, ['a'], ['b', 'c'])
+    params = Triglav::Agent::StorageFile.load(file)
+    assert { params = {'a' => {'b' => 'val', 'c' => 'val'} } }
+  end
 end


### PR DESCRIPTION
We remove statuses for resources which are not given from triglav core anymore so that we can start up from latest (I mean, not to resume) when we re-register the same resource uri to triglav core.